### PR TITLE
Fix Poetry build and setup Trusted Publishing

### DIFF
--- a/.github/workflows/python-publish.yml
+++ b/.github/workflows/python-publish.yml
@@ -4,6 +4,9 @@ on:
   push:
     branches:
       - main
+  pull_request:
+    branches:
+      - main
   release:
     types:
       - published

--- a/.github/workflows/python-publish.yml
+++ b/.github/workflows/python-publish.yml
@@ -1,33 +1,51 @@
-name: Upload power_decos Package
+name: Publish Python 🐍 distributions 📦 to PyPI
 
 on:
+  push:
+    branches:
+      - main
   release:
-    types: [published]
-
-permissions:
-  contents: read
+    types:
+      - published
 
 jobs:
-  deploy:
-
+  build:
+    name: Build distribution 📦
     runs-on: ubuntu-latest
+    permissions:
+      attestations: write
+      id-token: write
 
     steps:
-    - uses: actions/checkout@v4
-    - name: Set up Python
-      uses: actions/setup-python@v3
+      - name: Checkout repository
+        uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # v4.1.7
+
+      - name: Build and inspect Python 🐍 package 📦
+        uses: hynek/build-and-inspect-python-package@73aea398b9c8de9ea9e4464c6b13cb8b1f3d6294 # v2.9.0
+        with:
+          attest-build-provenance-github: ${{ github.event.action == 'published' }}
+
+  publish-to-pypi:
+    name: Publish Python 🐍 distribution 📦 to PyPI
+    needs: build
+    if: ${{ github.event.action == 'published' }}
+    runs-on: ubuntu-latest
+    environment:
+      name: pypi
+      url: https://pypi.org/project/power-decos/${{ github.ref_name }}
+    permissions:
+      id-token: write
+
+    steps:
+    - name: Download dists
+      uses: actions/download-artifact@fa0a91b85d4f404e444e00e005971372dc801d16 # v4.1.8
       with:
-        python-version: '3.12'
-    - name: Install dependencies
-      run: |
-        python -m pip install --upgrade pip
-        pip install poetry
-        poetry install --no-dev  # Install dependencies specific to power_decos
-    - name: Build package
-      run: |
-        poetry build  # Use poetry to build the package
-    - name: Publish package
-      uses: pypa/gh-action-pypi-publish@v1.5.0  # Use a stable version
+        name: Packages
+        path: dist/
+
+    - name: Publish distribution 📦 to PyPI
+      uses: pypa/gh-action-pypi-publish@0ab0b79471669eb3a4d647e625009c62f9f3b241 # v1.10.1
       with:
-        user: __token__
-        password: ${{ secrets.PYPI_API_TOKEN }}
+          attestations: true
+          verbose: true
+          print-hash: true

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -12,8 +12,11 @@ keywords = ["decorators", "log", "retry", "get_time", "cache"]
 [tool.poetry.dependencies]
 python = "^3.8"
 
-[tool.poetry.dev-dependencies]
+[tool.poetry.group.dev.dependencies]
 pytest = "^8.3.2"
+
+[tool.poetry.group.docs.dependencies]
+sphinx = "^8.0.2"
 
 [build-system]
 requires = ["poetry-core>=1.0.0"]
@@ -23,8 +26,3 @@ build-backend = "poetry.core.masonry.api"
 minversion = "8.3.2"
 addopts = "-v"
 testpaths = ["tests"]
-
-[project.optional-dependencies]
-docs = ["sphinx"]
-
-


### PR DESCRIPTION
`[project.optional-dependencies]` existed which was causing Poetry to try to parse project metadata from the `[project]` table.
Also switching to Trusted Publishing in this PR.
