### PR TITLE
Remove duplicate build system specifier

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,7 +1,3 @@
-[build-system]
-requires = ["poetry-core>=1.0.0"]
-build-backend = "poetry.core.masonry.api"
-
 [tool.poetry]
 name = "power_decos"
 version = "0.1.3"


### PR DESCRIPTION
Accidently added it back in https://github.com/MrCode200/power_decos/commit/9839c10b49fc62cc4953962d0d3fb4e6f07f817c after it was moved in https://github.com/MrCode200/power_decos/commit/2f8a0246c9480ca0351a32c1317867780b2c819e